### PR TITLE
Add service resolvers

### DIFF
--- a/projects/demo/src/app/core/home/home.component.ts
+++ b/projects/demo/src/app/core/home/home.component.ts
@@ -12,7 +12,7 @@ import {
   AccessTokenService,
   IdTokenInfo,
   IdTokenService,
-  JwkService,
+  JwkServiceResolver,
 } from '@mrpachara/ngx-oauth2-access-token';
 
 @Component({
@@ -26,7 +26,7 @@ import {
 export class HomeComponent {
   private readonly accessTokenService = inject(AccessTokenService);
   private readonly idTokenService = inject(IdTokenService);
-  private readonly jwkService = inject(JwkService);
+  private readonly jwkServiceResolver = inject(JwkServiceResolver);
 
   protected readonly errorAccessTokenMessage = signal<string | null>(null);
   protected readonly errorIdTokenMessage = signal<string | null>(null);
@@ -70,7 +70,11 @@ export class HomeComponent {
       filter(
         (idToken): idToken is IdTokenInfo => typeof idToken !== 'undefined',
       ),
-      switchMap((idToken) => this.jwkService.verify(idToken)),
+      switchMap(async (idToken) =>
+        this.jwkServiceResolver
+          .findByIssuer(idToken.header.iss ?? idToken.payload.iss ?? '')
+          ?.verify(idToken),
+      ),
     ),
   );
 }

--- a/projects/demo/src/secrets/.gitignore
+++ b/projects/demo/src/secrets/.gitignore
@@ -1,1 +1,1 @@
-*.private.ts
+**/*.private.*

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers.ts
@@ -1,0 +1,4 @@
+export * from './service-resolvers/oauth2-client.resolver';
+export * from './service-resolvers/access-token-service.resolver';
+export * from './service-resolvers/authorization-code-service.resolver';
+export * from './service-resolvers/jwk-service-service.resolver';

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/access-token-service.resolver.spec.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/access-token-service.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AccessTokenServiceResolver } from './access-token-service.resolver';
+
+describe('AccessTokenServiceResolver', () => {
+  let service: AccessTokenServiceResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AccessTokenServiceResolver);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/access-token-service.resolver.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/access-token-service.resolver.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { ACCESS_TOKEN_SERVICES } from '../tokens';
+import { AccessTokenService } from '../services';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AccessTokenServiceResolver {
+  private readonly accessTokenServices = inject(ACCESS_TOKEN_SERVICES);
+
+  find(name: string): AccessTokenService | null {
+    for (const accessTokenService of this.accessTokenServices) {
+      if (accessTokenService.name === name) {
+        return accessTokenService;
+      }
+    }
+
+    return null;
+  }
+}

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/authorization-code-service.resolver.spec.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/authorization-code-service.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthorizationCodeServiceResolver } from './authorization-code-service.resolver';
+
+describe('AuthorizationCodeServiceResolver', () => {
+  let service: AuthorizationCodeServiceResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthorizationCodeServiceResolver);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/authorization-code-service.resolver.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/authorization-code-service.resolver.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject } from '@angular/core';
+import { AUTHORIZATION_CODE_SERVICES } from '../tokens';
+import { AuthorizationCodeService } from '../services';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthorizationCodeServiceResolver {
+  private readonly authorizationCodeServices = inject(
+    AUTHORIZATION_CODE_SERVICES,
+  );
+
+  find(name: string): AuthorizationCodeService | null {
+    for (const authorizationCodeService of this.authorizationCodeServices) {
+      if (authorizationCodeService.name === name) {
+        return authorizationCodeService;
+      }
+    }
+
+    return null;
+  }
+}

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/jwk-service-service.resolver.spec.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/jwk-service-service.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { JwkServiceResolver } from './jwk-service-service.resolver';
+
+describe('JwkServiceResolver', () => {
+  let service: JwkServiceResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(JwkServiceResolver);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/jwk-service-service.resolver.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/jwk-service-service.resolver.ts
@@ -1,0 +1,30 @@
+import { Injectable, inject } from '@angular/core';
+import { JWK_SERVICES } from '../tokens';
+import { JwkService } from '../services';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class JwkServiceResolver {
+  private readonly jwkServices = inject(JWK_SERVICES);
+
+  find(name: string): JwkService | null {
+    for (const jwkService of this.jwkServices) {
+      if (jwkService.name === name) {
+        return jwkService;
+      }
+    }
+
+    return null;
+  }
+
+  findByIssuer(issuer: string): JwkService | null {
+    for (const jwkService of this.jwkServices) {
+      if (jwkService.issuer === issuer) {
+        return jwkService;
+      }
+    }
+
+    return null;
+  }
+}

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/oauth2-client.resolver.spec.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/oauth2-client.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Oauth2ClientResolver } from './oauth2-client.resolver';
+
+describe('Oauth2ClientResolver', () => {
+  let service: Oauth2ClientResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Oauth2ClientResolver);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/oauth2-client.resolver.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/service-resolvers/oauth2-client.resolver.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { OATUTH2_CLIENTS } from '../tokens';
+import { Oauth2Client } from '../services';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class Oauth2ClientResolver {
+  private readonly oauth2Clients = inject(OATUTH2_CLIENTS);
+
+  find(name: string): Oauth2Client | null {
+    for (const oauth2Client of this.oauth2Clients) {
+      if (oauth2Client.name === name) {
+        return oauth2Client;
+      }
+    }
+
+    return null;
+  }
+}

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
@@ -53,6 +53,10 @@ export class AccessTokenService {
 
   private readonly accessTokenResponse$: Observable<StoredAccessTokenResponse>;
 
+  get name() {
+    return this.config.name;
+  }
+
   constructor(
     private readonly config: AccessTokenFullConfig,
     private readonly client: Oauth2Client,

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/authorization-code.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/authorization-code.service.ts
@@ -33,6 +33,10 @@ export class AuthorizationCodeService {
   private readonly storageFactory = inject(AuthorizationCodeStorageFactory);
   private readonly storage: AuthorizationCodeStorage;
 
+  get name() {
+    return this.config.name;
+  }
+
   constructor(
     private readonly config: AuthorizationCodeFullConfig,
     private readonly client: Oauth2Client,

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/jwk.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/jwk.service.ts
@@ -15,6 +15,14 @@ export class JwkService {
   private http = inject(HttpClient);
   private verifiers = inject(JWT_VERIFIERS);
 
+  get name() {
+    return this.config.name;
+  }
+
+  get issuer() {
+    return this.config.issuer;
+  }
+
   constructor(private readonly config: JwkFullConfig) {}
 
   private fetchJwkSet(): Observable<JwkSet> {

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/oauth2.client.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/oauth2.client.ts
@@ -18,6 +18,10 @@ import {
 export class Oauth2Client {
   private readonly http = inject(HttpClient);
 
+  get name() {
+    return this.config.name;
+  }
+
   constructor(
     private readonly config: Oauth2ClientFullConfig,
     private readonly errorTransformer: Oauth2ClientErrorTransformer,

--- a/projects/mrpachara/ngx-oauth2-access-token/src/public-api.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/public-api.ts
@@ -8,6 +8,7 @@ export * from './lib/errors';
 export * from './lib/functions';
 
 export * from './lib/services';
+export * from './lib/service-resolvers';
 
 export * from './lib/provide-key-value-pair-storage';
 export * from './lib/provide-oauth2-client';


### PR DESCRIPTION
For multiple instances of services, e.g. `Oauth2Client` or `AccessTokenService`, it could be good to have the `resolver`s that can get service instance by `name` of configuration. Especially `JwkService`, it could be get by using `issuer` as requested #20 .