### PR TITLE
The public methods of `AccessTokenResponseExtractor` can be called directly.

### DIFF
--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/refresh-token.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/refresh-token.service.ts
@@ -19,6 +19,7 @@ import {
   AccessTokenResponseExtractor,
   AccessTokenResponseInfo,
   AccessTokenServiceInfo,
+  AccessTokenServiceInfoProvidable,
   ExtractorPipeReturn,
   RefreshTokenFullConfig,
   Scopes,
@@ -112,9 +113,11 @@ export class RefreshTokenService
   }
 
   exchangeRefreshToken(
-    serviceInfo: AccessTokenServiceInfo<RefreshTokenFullConfig>,
+    serviceInfoProvidable: AccessTokenServiceInfoProvidable,
     scopes?: Scopes,
   ): Observable<AccessTokenResponse> {
+    const serviceInfo = serviceInfoProvidable.serviceInfo(this);
+
     return defer(() => this.loadRefreshToken(serviceInfo)).pipe(
       switchMap((token) => {
         const scope = scopes ? validateAndTransformScopes(scopes) : null;

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/types/oauth2-services.types.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/types/oauth2-services.types.ts
@@ -48,6 +48,12 @@ export interface AccessTokenResponseExtractor<
   ): ExtractorPipeReturn<T, R>;
 }
 
+export interface AccessTokenServiceInfoProvidable {
+  serviceInfo<T extends AccessTokenResponse, C>(
+    extractor: AccessTokenResponseExtractor<T, C>,
+  ): AccessTokenServiceInfo<C>;
+}
+
 export type AccessTokenInfo = {
   type: string;
   token: string;


### PR DESCRIPTION
From #25 , the signature of `AccessTokenResponseExtractor` public methods must be changed. They get the instance of `AccessTokenService` instead of `ServiceInfo`. And `serviceInfo()` visibility was changed to `public`.