### PR TITLE
Remove `debug` property use `isDevMode()` instead

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "prettier.prettierPath": "./node_modules/prettier",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/projects/demo/src/app/app.config.long.ts
+++ b/projects/demo/src/app/app.config.long.ts
@@ -39,7 +39,6 @@ import { routes } from './app.routes';
 
 const clientConfig: Oauth2ClientConfig = {
   name: 'google',
-  debug: true,
   clientId: clientId,
   clientSecret: clientSecret,
   accessTokenUrl: 'https://oauth2.googleapis.com/token',
@@ -47,7 +46,6 @@ const clientConfig: Oauth2ClientConfig = {
 
 const authorizationCodeConfig: AuthorizationCodeConfig = {
   name: 'google',
-  debug: true,
   authorizationCodeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
   redirectUri: 'http://localhost:4200/google/authorization',
   pkce: 'S256',
@@ -60,7 +58,6 @@ const authorizationCodeConfig: AuthorizationCodeConfig = {
 
 const accessTokenConfig: AccessTokenConfig = {
   name: 'google',
-  debug: true,
 };
 
 // NOTE: configIdToken() returns the full configuration
@@ -71,7 +68,6 @@ const idTokenFullConfig = configIdToken({
 
 const jwkConfig: JwkConfig = {
   name: 'google',
-  debug: true,
   issuer: 'https://accounts.google.com',
   jwkSetUrl: 'https://www.googleapis.com/oauth2/v3/certs',
 };

--- a/projects/demo/src/app/app.config.short.ts
+++ b/projects/demo/src/app/app.config.short.ts
@@ -34,7 +34,6 @@ import { routes } from './app.routes';
 
 const clientConfig: Oauth2ClientConfig = {
   name: 'google',
-  debug: true,
   clientId: clientId,
   clientSecret: clientSecret,
   accessTokenUrl: 'https://oauth2.googleapis.com/token',
@@ -42,7 +41,6 @@ const clientConfig: Oauth2ClientConfig = {
 
 const authorizationCodeConfig: AuthorizationCodeConfig = {
   name: 'google',
-  debug: true,
   authorizationCodeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
   redirectUri: 'http://localhost:4200/google/authorization',
   pkce: 'S256',
@@ -55,7 +53,6 @@ const authorizationCodeConfig: AuthorizationCodeConfig = {
 
 const accessTokenConfig: AccessTokenConfig = {
   name: 'google',
-  debug: true,
 };
 
 // NOTE: configIdToken() returns the full configuration
@@ -66,7 +63,6 @@ const idTokenFullConfig = configIdToken({
 
 const jwkConfig: JwkConfig = {
   name: 'google',
-  debug: true,
   issuer: 'https://accounts.google.com',
   jwkSetUrl: 'https://www.googleapis.com/oauth2/v3/certs',
 };

--- a/projects/mrpachara/ngx-oauth2-access-token/README.md
+++ b/projects/mrpachara/ngx-oauth2-access-token/README.md
@@ -47,7 +47,6 @@ import { defer } from 'rxjs';
 
 const clientConfig: Oauth2ClientConfig = {
   name: 'google',
-  debug: true,
   clientId: 'CLIENT_ID',
   clientSecret: 'CLIENT_SECRET',
   accessTokenUrl: 'https://oauth2.googleapis.com/token',
@@ -55,7 +54,6 @@ const clientConfig: Oauth2ClientConfig = {
 
 const authorizationCodeConfig: AuthorizationCodeConfig = {
   name: 'google',
-  debug: true,
   authorizationCodeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
   redirectUri: 'http://localhost:4200/google/authorization',
   pkce: 'S256',
@@ -68,7 +66,6 @@ const authorizationCodeConfig: AuthorizationCodeConfig = {
 
 const accessTokenConfig: AccessTokenConfig = {
   name: 'google',
-  debug: true,
 };
 
 // NOTE: configIdToken() returns the full configuration
@@ -260,7 +257,6 @@ File: `src/app/app.config.ts`
 ```typescript
 const jwkConfig: JwkConfig = {
   name: 'google',
-  debug: true,
   issuer: 'https://accounts.google.com',
   jwkSetUrl: 'https://www.googleapis.com/oauth2/v3/certs',
 };

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/functions/config.functions.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/functions/config.functions.ts
@@ -17,7 +17,6 @@ import {
 export const defaultOauth2ClientConfig: PickOptional<
   Omit<Oauth2ClientConfig, 'clientSecret'>
 > = {
-  debug: false,
   clientCredentialsInParams: false,
 };
 
@@ -33,7 +32,6 @@ export function configOauth2Client(
 const defaultAccessTokenTtl = 10 * 60 * 1000;
 
 export const defaultAccessTokenConfig: PickOptional<AccessTokenConfig> = {
-  debug: false,
   additionalParams: {},
   accessTokenTtl: defaultAccessTokenTtl,
 };
@@ -52,7 +50,6 @@ const defaultCodeVerifierLength = 56;
 
 export const defaultAuthorizationCodeConfig: PickOptional<AuthorizationCodeConfig> =
   {
-    debug: false,
     pkce: 'none',
     stateTtl: defaultStateTtl,
     codeVerifierLength: defaultCodeVerifierLength,
@@ -94,9 +91,7 @@ export function configIdToken(config: IdTokenConfig): IdTokenFullConfig {
   };
 }
 
-export const defaultJwkConfig: PickOptional<JwkConfig> = {
-  debug: false,
-};
+export const defaultJwkConfig: PickOptional<JwkConfig> = {};
 
 export function configJwk(config: JwkConfig): JwkFullConfig {
   return {

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.spec.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.spec.ts
@@ -24,7 +24,6 @@ const oauth2ClientConfig: Oauth2ClientConfig = {
 
 const accessTokenServiceConfig: AccessTokenConfig = {
   name: 'oauth2',
-  debug: false,
 };
 
 describe('AccessTokenService', () => {

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
@@ -1,4 +1,4 @@
-import { inject } from '@angular/core';
+import { inject, isDevMode } from '@angular/core';
 import {
   catchError,
   defer,
@@ -46,6 +46,7 @@ import {
   ACCESS_TOKEN_RESPONSE_EXTRACTOR_INFOS,
   DEFAULT_ACCESS_TOKEN_RESPONSE_EXTRACTOR_INFOS,
 } from '../tokens';
+import { HttpErrorResponse } from '@angular/common/http';
 
 const latencyTime = 2 * 5 * 1000;
 
@@ -135,14 +136,21 @@ export class AccessTokenService implements AccessTokenServiceInfoProvidable {
             }),
             catchError((err) => {
               if (this.renewAccessToken$) {
-                if (this.config.debug) console.log(err);
+                if (isDevMode() && !(err instanceof HttpErrorResponse)) {
+                  console.log(err);
+                }
+
+                if (err instanceof HttpErrorResponse) {
+                  console.warn(err);
+                }
+
                 return this.renewAccessToken$.pipe(this.storeTokenPipe);
               } else {
                 return throwError(() => err);
               }
             }),
             tap(() => {
-              if (this.config.debug) {
+              if (isDevMode()) {
                 console.log('access-token-race:', 'I am a winner!!!');
               }
             }),
@@ -158,7 +166,7 @@ export class AccessTokenService implements AccessTokenServiceInfoProvidable {
             ),
             take(1),
             tap(() => {
-              if (this.config.debug) {
+              if (isDevMode()) {
                 console.log('access-token-race:', 'I am a loser!!!');
               }
             }),
@@ -230,7 +238,7 @@ export class AccessTokenService implements AccessTokenServiceInfoProvidable {
         ),
     );
 
-    if (this.config.debug) {
+    if (isDevMode()) {
       const errors = results
         .filter(
           (result): result is PromiseRejectedResult =>
@@ -262,7 +270,7 @@ export class AccessTokenService implements AccessTokenServiceInfoProvidable {
         ),
     );
 
-    if (this.config.debug) {
+    if (isDevMode()) {
       const errors = results
         .filter(
           (result): result is PromiseRejectedResult =>

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/types/config.types.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/types/config.types.ts
@@ -6,16 +6,12 @@ type NameableConfig = {
   readonly name: string;
 };
 
-type DebugableConfig = {
-  readonly debug: boolean;
-};
-
 type AdditionalParams = {
   readonly additionalParams: { readonly [param: string]: string };
 };
 
 export type Oauth2ClientConfig = NameableConfig &
-  Partial<DebugableConfig> & {
+   {
     readonly clientId: string;
     readonly clientSecret?: string;
     readonly accessTokenUrl: string;
@@ -28,7 +24,6 @@ export type Oauth2ClientFullConfig = RequiredExcept<
 >;
 
 export type AccessTokenConfig = NameableConfig &
-  Partial<DebugableConfig> &
   Partial<AdditionalParams> & {
     readonly accessTokenTtl?: number;
   };
@@ -41,7 +36,6 @@ export type AccessTokenResponseExtractorInfo<
 export type AccessTokenFullConfig = Required<AccessTokenConfig>;
 
 export type AuthorizationCodeConfig = NameableConfig &
-  Partial<DebugableConfig> &
   Partial<AdditionalParams> & {
     readonly authorizationCodeUrl: string;
     readonly redirectUri: string;
@@ -64,8 +58,7 @@ export type IdTokenConfig = {
 
 export type IdTokenFullConfig = Required<IdTokenConfig>;
 
-export type JwkConfig = NameableConfig &
-  Partial<DebugableConfig> & {
+export type JwkConfig = NameableConfig & {
     readonly issuer: string;
     readonly jwkSetUrl: string;
   };


### PR DESCRIPTION
From #28 , most services can be used without configuration. So assigning `debug` in a configuration doesn't suit them. We use system-wide `isDevMode()` instead.