### PR TITLE
Add `watchMode` to `fetchXxx()` functions and `extract()`

### DIFF
--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
@@ -8,11 +8,11 @@ import {
   from,
   map,
   Observable,
-  ObservableInput,
   of,
   pipe,
   race,
   share,
+  Subject,
   switchMap,
   take,
   tap,
@@ -77,6 +77,9 @@ export class AccessTokenService implements AccessTokenServiceInfoProvidable {
   private readonly listeners: AccessTokenResponseExtractor[];
 
   private readonly accessTokenResponse$: Observable<StoredAccessTokenResponse>;
+
+  private readonly watchAccessTokenResponse$ =
+    new Subject<StoredAccessTokenResponse>();
 
   get name() {
     return this.config.name;
@@ -353,19 +356,6 @@ export class AccessTokenService implements AccessTokenServiceInfoProvidable {
   ): Observable<R> {
     return this.fetchResponse<T>().pipe(
       extractor.extractPipe(this.serviceInfo(extractor)),
-    );
-  }
-
-  ready<R>(
-    process: (
-      accessTokenInfo: AccessTokenInfo,
-      serviceName: string,
-    ) => ObservableInput<R>,
-  ): Observable<R> {
-    return this.fetchToken().pipe(
-      switchMap((accessTokenInfo) =>
-        process(accessTokenInfo, this.config.name),
-      ),
     );
   }
 

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/storage/access-token.storage.factory.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/storage/access-token.storage.factory.ts
@@ -10,15 +10,14 @@ const tokenDataKeyName = `access-token-data` as const;
 export class AccessTokenStorage {
   private stoageKey = () => `${this.name}-${tokenDataKeyName}` as const;
 
-  private readonly accessToken$: Observable<StoredAccessTokenResponse | null>;
+  private readonly accessTokenResponse$: Observable<StoredAccessTokenResponse | null>;
 
   constructor(
     private readonly name: string,
     private readonly storage: KeyValuePairStorage,
   ) {
-    this.accessToken$ = this.storage.watchItem<StoredAccessTokenResponse>(
-      this.stoageKey(),
-    );
+    this.accessTokenResponse$ =
+      this.storage.watchItem<StoredAccessTokenResponse>(this.stoageKey());
   }
 
   async loadAccessTokenResponse(): Promise<StoredAccessTokenResponse> {
@@ -46,7 +45,7 @@ export class AccessTokenStorage {
   }
 
   watchAccessTokenResponse(): Observable<StoredAccessTokenResponse | null> {
-    return this.accessToken$;
+    return this.accessTokenResponse$;
   }
 }
 

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/storage/local-storage/local.storage.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/storage/local-storage/local.storage.ts
@@ -87,7 +87,7 @@ export class LocalStorage implements KeyValuePairStorage {
 
     localStorage.setItem(this.stoageKey(key), this.transformToStorage(value));
 
-    return value;
+    return await (this.loadItem<T>(key) as Promise<T>);
   }
 
   async removeItem<T = unknown>(key: string): Promise<T | null> {


### PR DESCRIPTION
From #30 , we can pass `watchMode` to `fetchToken()`, `fetchResponse()` and `extract()` for observing value changed. The `watchMode` is `false` by default for backward complatible.