### PR TITLE
Move `exchangeRefreshToken()` back to `AccessTokenService`

### DIFF
--- a/projects/demo/src/app/core/home/home.component.html
+++ b/projects/demo/src/app/core/home/home.component.html
@@ -1,7 +1,5 @@
 <div>
-  <button type="button" (click)="exchangeAccessToken()">
-    Exchange Access Token
-  </button>
+  <button type="button" (click)="renewAccessToken()">Renew Access Token</button>
 </div>
 
 <h2>Access Token</h2>

--- a/projects/demo/src/app/core/home/home.component.ts
+++ b/projects/demo/src/app/core/home/home.component.ts
@@ -13,7 +13,6 @@ import {
   IdTokenInfo,
   IdTokenService,
   JwkServiceResolver,
-  RefreshTokenService,
 } from '@mrpachara/ngx-oauth2-access-token';
 
 @Component({
@@ -27,7 +26,6 @@ import {
 export class HomeComponent {
   private readonly accessTokenService = inject(AccessTokenService);
   private readonly idTokenService = inject(IdTokenService);
-  private readonly refreshTokenService = inject(RefreshTokenService);
   private readonly jwkServiceResolver = inject(JwkServiceResolver);
 
   protected readonly errorAccessTokenMessage = signal<string | null>(null);
@@ -78,16 +76,7 @@ export class HomeComponent {
     ),
   );
 
-  exchangeAccessToken(): void {
-    this.refreshTokenService
-      .exchangeRefreshToken(this.accessTokenService)
-      .pipe(take(1))
-      .subscribe({
-        next: async (accessTokenResponse) => {
-          await this.accessTokenService.setAccessTokenResponse(
-            accessTokenResponse,
-          );
-        },
-      });
+  renewAccessToken(): void {
+    this.accessTokenService.exchangeRefreshToken().pipe(take(1)).subscribe();
   }
 }


### PR DESCRIPTION
From putting  `exchangeRefreshToken()` on `RefreshTokenService`, when we call  `exchangeRefreshToken()` it doesn't store the new access token in storage because it's out of `RefreshTokenService` scope. That is not make sense to store it manually. So move it back to `AccessTokenService`.