### PR TITLE
fix(oat): change resource to flat-stream-resource

### DIFF
--- a/projects/demo/src/app/core/home/home.html
+++ b/projects/demo/src/app/core/home/home.html
@@ -56,11 +56,11 @@
           }
         </dl>
       </div>
-    } @else {
-      <div>
-        <button type="button" (click)="authorization()">Authorization</button>
-      </div>
     }
+  } @else if (!accessTokenResource.isLoading()) {
+    <div>
+      <button type="button" (click)="authorization()">Authorization</button>
+    </div>
   }
 
   @if (errorAccessTokenMessage(); as errorMessage) {

--- a/projects/mrpachara/ngx-oauth2-access-token/package.json
+++ b/projects/mrpachara/ngx-oauth2-access-token/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrpachara/ngx-oauth2-access-token",
-  "version": "0.0.1-pre.17",
+  "version": "0.0.1-pre.18",
   "keywords": [
     "angular",
     "oauth 2.0"

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
@@ -11,7 +11,7 @@ import {
   RefreshTokenExpiredError,
   RefreshTokenNotFoundError,
 } from '../errors';
-import { validateAndTransformScopes } from '../helpers';
+import { flatStreamResource, validateAndTransformScopes } from '../helpers';
 import { libPrefix } from '../predefined';
 import {
   ACCESS_TOKEN_CONFIG,
@@ -95,20 +95,24 @@ export class AccessTokenService {
 
   readonly #ready = signal<boolean | undefined>(undefined);
   readyResource() {
-    return resource({
-      params: () => this.#ready(),
-      loader: async ({ params: ready }) => ready,
-    });
+    return flatStreamResource(
+      resource({
+        params: () => this.#ready(),
+        loader: async ({ params: ready }) => ready,
+      }),
+    ).asReadonly();
   }
 
   readonly #lastUpdated = signal<AccessTokenResponseUpdatedData | undefined>(
     undefined,
   );
   accessTokenResponseResource() {
-    return resource({
-      params: () => this.#lastUpdated()?.timestamp ?? Date.now(),
-      loader: async () => await this.loadAccessTokenResponse(),
-    });
+    return flatStreamResource(
+      resource({
+        params: () => this.#lastUpdated() ?? Date.now(),
+        loader: async () => await this.loadAccessTokenResponse(),
+      }),
+    ).asReadonly();
   }
 
   readonly #uuid = crypto.randomUUID();

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/id-token.extractor.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/id-token.extractor.ts
@@ -4,7 +4,7 @@ import {
   IdTokenEncryptedError,
   IdTokenInfoNotFoundError,
 } from '../errors';
-import { deserializeJose, isJwt } from '../helpers';
+import { deserializeJose, flatStreamResource, isJwt } from '../helpers';
 import { EXTRACTOR_ID } from '../tokens';
 import {
   ID_TOKEN_CLAIMS_TRANSFORMER,
@@ -108,19 +108,21 @@ export class IdTokenExtractor
   }
 
   infoResource() {
-    return resource({
-      params: () => this.#internalUpdated(),
-      loader: async () => {
-        const result = await this.loadInfo();
+    return flatStreamResource(
+      resource({
+        params: () => this.#internalUpdated(),
+        loader: async () => {
+          const result = await this.loadInfo();
 
-        if (typeof result === 'undefined') {
-          throw new IdTokenInfoNotFoundError(this.name);
-        }
+          if (typeof result === 'undefined') {
+            throw new IdTokenInfoNotFoundError(this.name);
+          }
 
-        return result;
-      },
-      equal: (oldValue, newValue) => oldValue.serial === newValue.serial,
-    });
+          return result;
+        },
+        equal: (oldValue, newValue) => oldValue.serial === newValue.serial,
+      }),
+    ).asReadonly();
   }
 
   async loadClaims(): Promise<IdTokenClaims | undefined> {
@@ -128,17 +130,19 @@ export class IdTokenExtractor
   }
 
   claimsResource() {
-    return resource({
-      params: () => this.#internalUpdated(),
-      loader: async () => {
-        const result = await this.loadClaims();
+    return flatStreamResource(
+      resource({
+        params: () => this.#internalUpdated(),
+        loader: async () => {
+          const result = await this.loadClaims();
 
-        if (typeof result === 'undefined') {
-          throw new IdTokenClaimsNotFoundError(this.name);
-        }
+          if (typeof result === 'undefined') {
+            throw new IdTokenClaimsNotFoundError(this.name);
+          }
 
-        return result;
-      },
-    });
+          return result;
+        },
+      }),
+    ).asReadonly();
   }
 }


### PR DESCRIPTION
Resource API sets `hasValue()` to `false` when it is loading by using the new `params`. So it must be flatted to single stream resource for preserving the old value until loading finishs.