### PR TITLE
fix(oat): make HTTP Authorization be correct case-sensitive schema

### DIFF
--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.spec.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.spec.ts
@@ -537,7 +537,7 @@ describe('AccessTokenService - simple configuration', () => {
 
       const result = await service.loadAccessTokenInfo();
 
-      expect(result).toEqual({ type: 'bearer', token: 'token' });
+      expect(result).toEqual({ type: 'Bearer', token: 'token' });
     });
 
     it('should return null when no access token available', async () => {

--- a/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
+++ b/projects/mrpachara/ngx-oauth2-access-token/src/lib/services/access-token.service.ts
@@ -110,6 +110,21 @@ function extractRefreshTokenTtl(
   return defaultRefreshTokenTtl * 1_000;
 }
 
+const standardTokenType = {
+  basic: 'Basic',
+  bearer: 'Bearer',
+  dpop: 'DPoP',
+  mac: 'MAC',
+};
+
+function standardizeTokenType(tokenType: string): string {
+  return (
+    standardTokenType[
+      tokenType.toLocaleLowerCase() as keyof typeof standardTokenType
+    ] ?? tokenType
+  );
+}
+
 @Service()
 export class AccessTokenService {
   private readonly config = configure(inject(ACCESS_TOKEN_CONFIG));
@@ -467,7 +482,7 @@ export class AccessTokenService {
     return accessTokenResponse === null
       ? null
       : {
-          type: accessTokenResponse.token_type,
+          type: standardizeTokenType(accessTokenResponse.token_type),
           token: accessTokenResponse.access_token,
         };
   }


### PR DESCRIPTION
The token_type and HTTP Authorization schema are case-insensitive but in some strict API gateways require case-sensitive HTTP Authorization schema.